### PR TITLE
feat: transfer inquiry from psychologist to doctor inquiries pool.

### DIFF
--- a/src/components/InquiryCard/InquiryCard.tsx
+++ b/src/components/InquiryCard/InquiryCard.tsx
@@ -8,7 +8,7 @@ import MaterialMenuItem from '@material-ui/core/MenuItem';
 
 import moment from '../../utils/moment';
 import { Inquiry } from '../../entities/Inquiry';
-import specialities, { getSpecialityLabel } from '../../constants/specialities';
+import { specialities, psychologistSpecialities, getSpecialityLabel, ISpeciality } from '../../constants/specialities';
 import { sdk } from '../../sdk';
 import { useSelector } from 'react-redux';
 import { getAuth } from '../../store/selectors/status';
@@ -71,8 +71,12 @@ export const InquiryCard: React.FunctionComponent<IInquiryCardProps> = (
     };
 
     const updateInquirySpeciality = (inquiry: Inquiry, speciality: string): () => void => {
-        return (): void => { sdk.inquiries.updateSpeciality(inquiry.id, speciality).then((inquiry: Inquiry) => {
-            onUpdateSpeciality && onUpdateSpeciality(inquiry); });
+        return (): void => {
+            if (speciality !== '') {
+                sdk.inquiries.updateSpeciality(inquiry.id, speciality).then((inquiry: Inquiry) => {
+                    onUpdateSpeciality && onUpdateSpeciality(inquiry);
+                });
+            }
         }
     };
 
@@ -144,7 +148,7 @@ export const InquiryCard: React.FunctionComponent<IInquiryCardProps> = (
         return inquiry.attended && (inquiry.doctorId === auth?.userId || !!auth?.isSuperAdmin());
     }
 
-    const renderInquiryCardSpecialist = (): React.ReactNode => {
+    const renderInquiryCardSpecialist = (specialities: ISpeciality[]): React.ReactNode => {
         return (
             <MaterialTextField
                 select
@@ -165,12 +169,12 @@ export const InquiryCard: React.FunctionComponent<IInquiryCardProps> = (
         )
     }
 
-    const renderSpeciality = (): React.ReactNode => {
+    const renderDoctorSpeciality = (): React.ReactNode => {
         return auth?.isDoctor() ?
             (
                 <div className="inquiry__speciality-field">
                     <label>{t('inquiry.speciality')}</label>
-                    {renderInquiryCardSpecialist()}
+                    {renderInquiryCardSpecialist(specialities)}
                 </div>
             ) :
             (
@@ -178,6 +182,17 @@ export const InquiryCard: React.FunctionComponent<IInquiryCardProps> = (
                     <strong>{t('inquiry.speciality')}</strong> {getSpecialityLabel(inquiry.speciality)}
                 </Typography>
             );
+    }
+
+    const renderPsychologistSpeciality = (): React.ReactNode => {
+        return auth?.isDoctor() ?
+            (
+                <div className="inquiry__speciality-field">
+                    <label>{t('inquiry.speciality')}</label>
+                    {renderInquiryCardSpecialist(psychologistSpecialities)}
+                </div>
+            ) :
+            null;
     }
 
     return (
@@ -192,7 +207,8 @@ export const InquiryCard: React.FunctionComponent<IInquiryCardProps> = (
                 {inquiry.doctorType === DoctorType.PSYCHOLOGIST && <Typography>
                     <strong>{t('inquiry.types.psychologist')}</strong>
                 </Typography>}
-                {inquiry.doctorType === DoctorType.REGULAR && renderSpeciality()}
+                {inquiry.doctorType === DoctorType.PSYCHOLOGIST && renderPsychologistSpeciality()}
+                {inquiry.doctorType === DoctorType.REGULAR && renderDoctorSpeciality()}
                 <Typography>
                     <strong>{t('inquiry.age')}</strong> {inquiry.age}
                 </Typography>

--- a/src/constants/specialities.ts
+++ b/src/constants/specialities.ts
@@ -85,5 +85,16 @@ export const specialities = [
     defaultSpeciality
 ];
 
+
+export const psychologistSpecialities = [
+    {
+        "label": "Psicología",
+        "value": ""
+    }, {
+        "label": "Psiquiatría",
+        "value": "psiquiatria"
+    }
+];
+
 export const inquirySpecialities = specialities.filter((speciality: ISpeciality) => speciality.value !== defaultSpeciality.value)
 export default specialities;

--- a/src/pages/InquiryDetail.tsx
+++ b/src/pages/InquiryDetail.tsx
@@ -19,7 +19,7 @@ export const InquiryDetail: React.FunctionComponent = (): JSX.Element => {
     let { id: inquiryId } = useParams<IInquiryDetailLocationState>();
     const [inquiry, setInquiry] = useState<Inquiry | null>(null);
 
-    const handleAttendEvent = (inquiry: Inquiry): void => {
+    const handleInquiryUpdatedEvent = (inquiry: Inquiry): void => {
         if (!inquiry.attended) {
             history.push(Routes.DOCTOR_DASHBOARD);
         }
@@ -38,7 +38,7 @@ export const InquiryDetail: React.FunctionComponent = (): JSX.Element => {
             <main className="main inquiry-detail">
                 <div className="container">
                     <BackHome />
-                    {inquiry && <InquiryCard inquiry={inquiry} isAdmin={false} onAttendEvent={handleAttendEvent}/>}
+                    {inquiry && <InquiryCard inquiry={inquiry} isAdmin={false} onAttendEvent={handleInquiryUpdatedEvent} onUpdateSpeciality={handleInquiryUpdatedEvent} />}
                 </div>
             </main>
             <Footer/>


### PR DESCRIPTION
Dropdown to change speciality is also included in the psychologist views. Same behaviour as doctor views but with only two options.
Speciality change for the psychology inquiries implies a change of doctorType. Inquiry will disappear from the list and the inquiry will available in the doctor's dashboard.
In the inquiry detail view, after the change, inquiry won't be visible and the page will be redirected to the inquiry list.